### PR TITLE
Update app icon resource in HomeView

### DIFF
--- a/app/src/main/java/de/schuettslaar/sensoration/views/home/HomeView.kt
+++ b/app/src/main/java/de/schuettslaar/sensoration/views/home/HomeView.kt
@@ -169,7 +169,7 @@ fun HomeAppBar() {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 appInfo?.let {
                     Image(
-                        painter = painterResource(id = R.drawable.ic_launcher_monochrome),
+                        painter = painterResource(id = R.mipmap.ic_launcher_foreground),
                         contentDescription = stringResource(R.string.app_icon_desc),
                         modifier = Modifier.padding(end = 8.dp)
                     )


### PR DESCRIPTION
This pull request includes a change to the `HomeView.kt` file to update the app icon resource used in the `HomeAppBar` function.

* [`app/src/main/java/de/schuettslaar/sensoration/views/home/HomeView.kt`](diffhunk://#diff-08d7d61ab0b60000288c091adab40d5e4d20acbf848c266f7ce0dbc62c75944dL172-R172): Updated the app icon resource from `R.drawable.ic_launcher_monochrome` to `R.mipmap.ic_launcher_foreground` in the `HomeAppBar` function.